### PR TITLE
Add some more server interactivity when managing the game board

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,4 +1,4 @@
-r<template>
+<template>
   <h1>Application</h1>
 
   <nav>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -14,7 +14,7 @@ r<template>
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 
 export default {
   name: 'App',
@@ -22,6 +22,14 @@ export default {
     ...mapState({
       user: 'user',
     }),
+  },
+
+  created () {
+    this.getTokenAuthData()
+  },
+
+  methods: {
+    ...mapActions(['getTokenAuthData']),
   },
 }
 </script>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -7,7 +7,7 @@ r<template>
     <router-link to="/register">Register</router-link>
     <router-link to="/login">Log In</router-link>
 
-    {{ user.username }}
+    <span>{{ user && user.userName }}</span>
   </nav>
   
   <router-view />

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -1,4 +1,3 @@
-//this is sample/fake backend logic to help us pretend to work with the server side
 export const registerUser = async (username, password) => {
   const response = await fetch('http://localhost:5000/api/auth/register', {
     method: 'POST',
@@ -25,6 +24,16 @@ export const loginUser = async (username, password) => {
       password
     })
   });
+
+  return response.json()
+}
+
+export const getTokenAuthData = async (token) => {
+  const response = await fetch('http://localhost:5000/api/auth', {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+  })
 
   return response.json()
 }

--- a/client/src/lib/api.js
+++ b/client/src/lib/api.js
@@ -37,3 +37,15 @@ export const getTokenAuthData = async (token) => {
 
   return response.json()
 }
+
+export const updateUserPosition = async ({ userId, token, direction }) => {
+  const response = await fetch(`http://localhost:5000/users/${userId}/position`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ direction })
+  })
+
+  return response.json()
+}

--- a/client/src/pages/Game.vue
+++ b/client/src/pages/Game.vue
@@ -14,15 +14,12 @@
       @click="handleCellClick(i - 1)"
     >
       <LeekIcon v-if="isPlayerAtPosition(i - 1)" />
-      <span v-else class="position">
-        {{ getRowFromIndex(i - 1)}},{{ getColFromIndex(i - 1) }}
-      </span>
     </div>
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import LeekIcon from '../components/LeekIcon'
 
 export default {
@@ -58,6 +55,8 @@ export default {
   },
 
   methods: {
+    ...mapActions(['updateUserPosition']),
+
     getRowFromIndex (index) {
       return Math.floor(index / this.boardSize)
     },
@@ -70,8 +69,8 @@ export default {
       const row = this.getRowFromIndex(index)
       const col = this.getColFromIndex(index)
       return (
-        row === this.position[0] && 
-        col === this.position[1]
+        row === this.position[1] && 
+        col === this.position[0]
       )
     },
 
@@ -92,8 +91,15 @@ export default {
       const row = this.getRowFromIndex(index)
       const col = this.getColFromIndex(index)
 
-      this.position[0] = row
-      this.position[1] = col
+      if (!this.isNextToPlayerPosition(index)) return
+
+      let direction = ''
+      if (row === this.position[1] - 1) direction += 'Up'
+      if (row === this.position[1] + 1) direction += 'Down'
+      if (col === this.position[0] + 1) direction += 'Left'
+      if (row === this.position[0] + 1) direction += 'Right'
+
+      this.updateUserPosition(direction)
     }
   }
 }

--- a/client/src/pages/Game.vue
+++ b/client/src/pages/Game.vue
@@ -5,7 +5,10 @@
   >
     <div 
       class="cell" 
-      :class="{ active: isPlayerAtPosition(i - 1) }"
+      :class="{ 
+        active: isPlayerAtPosition(i - 1),
+        'can-move-to': isNextToPlayerPosition(i - 1),
+      }"
       v-for="i of (boardSize * boardSize)"
       :key="i"
       @click="handleCellClick(i - 1)"
@@ -72,6 +75,19 @@ export default {
       )
     },
 
+    isNextToPlayerPosition (index) {
+      const [x, y] = this.position
+
+      const row = this.getRowFromIndex(index)
+      const col = this.getColFromIndex(index)
+
+      if (col === x && row === y) return false
+      return (
+        (col >= x - 1 && col <= x + 1) &&
+        (row >= y - 1 && row <= y + 1)
+      )
+    },
+
     handleCellClick (index) {
       const row = this.getRowFromIndex(index)
       const col = this.getColFromIndex(index)
@@ -108,12 +124,17 @@ export default {
 
   background-color: white;
 
-  cursor: pointer;
+  cursor: default;
   user-select: none;
 }
 
 .cell.active {
   background-color: black;
+}
+
+.cell.can-move-to {
+  background-color: #DDD;
+  cursor: pointer;
 }
 
 .position {

--- a/client/src/pages/Game.vue
+++ b/client/src/pages/Game.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import LeekIcon from '../components/LeekIcon'
 
 export default {
@@ -30,10 +31,16 @@ export default {
 
   data: () => ({
     boardSize: 20,
-    position: [0, 0],
   }),
 
   computed: {
+    ...mapState({
+      position: ({ user }) => {
+        if (!user) return [0, 0]
+        return [user.positionX, user.positionY]
+      }
+    }),
+
     positionText () {
       const row = this.position[0]
       const col = this.position[1]

--- a/client/src/pages/Login.vue
+++ b/client/src/pages/Login.vue
@@ -13,8 +13,7 @@
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex'
-import { loginUser } from '../lib/api'
+import { mapActions, mapState, mapMutations } from 'vuex'
 
 export default {
   name: 'LoginPage',
@@ -29,13 +28,16 @@ export default {
     }),
   },
   methods: {
+    ...mapActions(['loginUser']),
     ...mapMutations(['setUser']),
 
     async handleFormSubmit () {
-      let response = await loginUser(this.username, this.password)
+      const response = await this.loginUser({
+        username: this.username,
+        password: this.password,
+      })
 
       if (response.result.succeeded) {
-        this.setUser({ username: this.username })
         this.$router.push('/game')
       }
       else {

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,5 +1,7 @@
 import { createWebHistory, createRouter } from 'vue-router'
 
+import store from '@/store'
+
 import Game from './pages/Game'
 import Home from './pages/Home'
 import Login from './pages/Login'
@@ -21,6 +23,13 @@ const routes = [
   {
     path: '/game',
     component: Game,
+    beforeEnter: (to, from, next) => {
+      if (!store.getters.isLoggedIn) {
+        return next('/login')
+      }
+
+      next()
+    }
   },
 ]
 

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -61,17 +61,21 @@ const actions = {
   },
 
   async updateUserPosition (context, direction) {
-    const response = await apiUpdateUserPosition({ 
-      userId: context.state.user.id,
-      token: context.state.token,
-      direction,
-    })
-
-    context.commit('setUser', {
-      ...context.state.user,
-      positionX: response.positionX,
-      positionY: response.positionY,
-    })
+    try {
+      const response = await apiUpdateUserPosition({ 
+        userId: context.state.user.id,
+        token: context.state.token,
+        direction,
+      })
+  
+      context.commit('setUser', {
+        ...context.state.user,
+        positionX: response.positionX,
+        positionY: response.positionY,
+      })
+    } catch (error) {
+      console.error('error updateUserPosition: ', error)
+    }
   },
 }
 

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -9,6 +9,12 @@ const state = {
   token: '',
 }
 
+const getters = {
+  isLoggedIn (state) {
+    return !!(state.user && state.user.id)
+  },
+}
+
 const actions = {
   async getTokenAuthData (context) {
     try {
@@ -66,6 +72,7 @@ const mutations = {
 
 const store = createStore({
   state,
+  getters,
   actions,
   mutations,
 })

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1,8 +1,27 @@
 import { createStore } from 'vuex'
+import { loginUser as apiLoginUser } from '@/lib/api'
 
 const state = {
   user: {},
   token: '',
+}
+
+const actions = {
+  async loginUser (context, userData) {
+    try {
+      const response = await apiLoginUser(userData.username, userData.password)
+
+      if (response.result.succeeded) {
+        context.commit('setUser', response.user)
+      } else {
+        context.commit('setUser', {})
+      }
+
+      return response
+    } catch (error) {
+      console.error(error)
+    }
+  },
 }
 
 const mutations = {
@@ -13,6 +32,7 @@ const mutations = {
 
 const store = createStore({
   state,
+  actions,
   mutations,
 })
 

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -2,6 +2,7 @@ import { createStore } from 'vuex'
 import { 
   loginUser as apiLoginUser,
   getTokenAuthData as apiGetTokenAuthData,
+  updateUserPosition as apiUpdateUserPosition,
 } from '@/lib/api'
 
 const state = {
@@ -57,7 +58,21 @@ const actions = {
       window.localStorage.removeItem('token')
       context.commit('setToken', '')
     }
-  }
+  },
+
+  async updateUserPosition (context, direction) {
+    const response = await apiUpdateUserPosition({ 
+      userId: context.state.user.id,
+      token: context.state.token,
+      direction,
+    })
+
+    context.commit('setUser', {
+      ...context.state.user,
+      positionX: response.positionX,
+      positionY: response.positionY,
+    })
+  },
 }
 
 const mutations = {


### PR DESCRIPTION
This takes care of the following cards on Trello:

- https://trello.com/c/oDIsBhRv/64-have-the-gameboard-communicate-with-the-server-to-update-position
- https://trello.com/c/eAEUe6lc/65-save-token-when-logging-in-to-use-for-future-api-requests
- https://trello.com/c/UZNiSvg7/66-redirect-user-away-from-game-board-unless-they-are-logged-in

Gist of updates:
- Made use of the authentication token provided by the server
- Don't let the user load the game board unless they are logged in
- Talk to the server when trying to update the position on the board.